### PR TITLE
Fixed cancel loading bug

### DIFF
--- a/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
+++ b/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
@@ -91,7 +91,8 @@
 }
 
 - (void)webView:(__unused UIWebView *)webView didFailLoadWithError:(NSError *)error {
-    [self.delegate checkoutAdapter:self didError:error];
+    if ([error code] != NSURLErrorCancelled) 
+        [self.delegate checkoutAdapter:self didError:error];
 }
 
 @end


### PR DESCRIPTION
When you cancel the initial payment view by pressing the cancel UIBarButtonItem, it dismisses the previous view as well. didFailLoadWithError gets called when you cancel the loading as well so without checking it messes up the interface's hierarchy.
